### PR TITLE
Pull docker images by digest

### DIFF
--- a/cmd/gootstrap/gootstrap.go
+++ b/cmd/gootstrap/gootstrap.go
@@ -9,9 +9,9 @@ import (
 	"github.com/NeowayLabs/gootstrap"
 )
 
-const GoVersion = "1.12.5"
+const GoDigest = "sha256:d17a1d8f0c20d108d1177d560f4afb9de10104c46df756d885cfa4282bbaac65" // golang:1.12.5-stretch
 const CILintVersion = "1.13.2"
-const AlpineVersion = "3.9"
+const AlpineDigest = "sha256:769fddc7cc2f0a1c35abb2f91432e8beecf83916c421420e6a6da9f8975464b6" // alpine:3.9
 
 func main() {
 
@@ -60,9 +60,9 @@ func main() {
 		Project:       project,
 		Module:        module,
 		DockerImg:     dockerimg,
-		GoVersion:     GoVersion,
+		GoDigest:      GoDigest,
 		CILintVersion: CILintVersion,
-		AlpineVersion: AlpineVersion,
+		AlpineDigest:  AlpineDigest,
 	}
 	gootstrap.CreateProject(cfg, outputdir)
 }

--- a/gootstrap.go
+++ b/gootstrap.go
@@ -16,9 +16,9 @@ type Config struct {
 	Project       string
 	Module        string
 	DockerImg     string
-	GoVersion     string
+	GoDigest      string
 	CILintVersion string
-	AlpineVersion string
+	AlpineDigest  string
 }
 
 // CreateProject creates a project

--- a/template/dockerfile.go
+++ b/template/dockerfile.go
@@ -1,6 +1,6 @@
 package template
 
-const DockerfileDev = `FROM golang:{{.GoVersion}}-stretch
+const DockerfileDev = `FROM golang@{{.GoDigest}}
 
 ENV GOLANG_CI_LINT_VERSION=v{{.CILintVersion}}
 
@@ -19,7 +19,7 @@ USER ${USER_ID}:${GROUP_ID}
 WORKDIR /app
 `
 
-const Dockerfile = `FROM alpine:{{.AlpineVersion}}
+const Dockerfile = `FROM alpine@{{.AlpineDigest}}
 
 RUN apk --no-cache update && \
     apk --no-cache add ca-certificates && \


### PR DESCRIPTION
Using a trusted docker image like golang:1.12.5-stretch is not always enough for security. People can intercept your request to provide a modified docker image.

[Always pull image by digest.](https://docs.docker.com/engine/reference/commandline/pull/#pull-an-image-by-digest-immutable-identifier)