### PR TITLE
Set docker to only downloads images that are signed

### DIFF
--- a/template/makefile.go
+++ b/template/makefile.go
@@ -28,10 +28,10 @@ modcache:
 	@mkdir -p $(modcachedir)
 
 image: build
-	docker build . -t $(img)
+	DOCKER_CONTENT_TRUST=1 docker build . -t $(img)
 
 imagedev:
-	docker build . -t $(imgdev) -f ./hack/Dockerfile $(dockerbuilduser)
+	DOCKER_CONTENT_TRUST=1 docker build . -t $(imgdev) -f ./hack/Dockerfile $(dockerbuilduser)
 
 release: guard-version publish
 	git tag -a $(version) -m "Generated release "$(version)


### PR DESCRIPTION
If we set the environment variable DOCKER_CONTENT_TRUST to 1, the docker only downloads images that are signed. So we can use tags safely for signed images. Just remembering that with tags the image may change (mutable).