### PR TITLE
Implement a tiny main abstraction

### DIFF
--- a/template/cmd.go
+++ b/template/cmd.go
@@ -5,6 +5,7 @@ const Cmd = `package main
 import (
 	"flag"
 	"fmt"
+	"os"
 )
 
 var (
@@ -13,14 +14,20 @@ var (
 )
 
 func main() {
+	if err := run(); err != nil {
+		fmt.Fprintf(os.Stderr, "%s\n", err)
+		os.Exit(1)
+	}
+}
 
+func run() error {
 	version := false
 	flag.BoolVar(&version, "version", false, "Show version")
 	flag.Parse()
 
 	if version {
 		fmt.Printf("version: %s\n", Version)
-		return
 	}
+	return nil
 }
 `


### PR DESCRIPTION
print error to standard error output and then exit
if you have a lot of things being set up in the main block you have to repeat that lots of time
very simple way to just return error